### PR TITLE
chore:(codeowners): replace vehicle-intelligence with asset-intelligence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @einride/vehicle-intelligence
+* @einride/asset-intelligence


### PR DESCRIPTION
## Update CODEOWNERS
### Why?
Vehicle Intelligence is now Asset Intelligence.
### What?
- Replace `einride/vehicle-intelligence` with `einride/asset-intelligence` in the CODEOWNERS file.
### Notes
- This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
